### PR TITLE
Add thumbnail-based file browser for splash selection

### DIFF
--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -13,6 +13,9 @@
 #include <cstring>
 #include "SystemConf.h"
 #include "Paths.h"
+#include "Settings.h"
+#include "utils/StringUtil.h"
+#include <map>
 
 #define WINDOW_WIDTH (float)Math::max((int)Renderer::getScreenHeight(), (int)(Renderer::getScreenWidth() * 0.65f))
 
@@ -227,11 +230,176 @@ std::vector<HelpPrompt> GuiFileBrowser::getHelpPrompts()
 
 void GuiFileBrowser::onOk(const std::string& path)
 {
-	if (Utils::FileSystem::isDirectory(mCurrentPath) && Settings::getInstance()->setString("LastFileBrowserFolder", mCurrentPath))
-		Settings::getInstance()->saveFile();
+        if (Utils::FileSystem::isDirectory(mCurrentPath) && Settings::getInstance()->setString("LastFileBrowserFolder", mCurrentPath))
+                Settings::getInstance()->saveFile();
 
-	if (mOkCallback)
-		mOkCallback(path);
+        if (mOkCallback)
+                mOkCallback(path);
 
-	delete this;
+        delete this;
+}
+
+//
+// GuiImageFileBrowser implementation
+//
+
+GuiImageFileBrowser::GuiImageFileBrowser(Window* window, const std::string startPath, const std::string selectedFile,
+        const std::function<void(const std::string&)>& okCallback, const std::string& title) :
+        GuiComponent(window), mGrid(window)
+{
+        setTag("popup");
+
+        mSelectedFile = Utils::FileSystem::getCanonicalPath(selectedFile);
+        mOkCallback = okCallback;
+
+        addChild(&mGrid);
+
+        auto theme = ThemeData::getMenuTheme();
+        float sh = (float)Math::min(Renderer::getScreenHeight(), Renderer::getScreenWidth());
+        sh = (float)theme->TextSmall.font->getSize() / sh;
+
+        std::string xml =
+                "<theme defaultView=\"Tiles\">"
+                "<formatVersion>7</formatVersion>"
+                "<view name=\"grid\">"
+                "<imagegrid name=\"gamegrid\">"
+                "  <margin>0.01 0.02</margin>"
+                "  <padding>0 0</padding>"
+                "  <scrollDirection>vertical</scrollDirection>"
+                "  <autoLayout>4 3</autoLayout>"
+                "  <autoLayoutSelectedZoom>1</autoLayoutSelectedZoom>"
+                "  <animateSelection>false</animateSelection>"
+                "  <centerSelection>false</centerSelection>"
+                "</imagegrid>"
+                "<gridtile name=\"default\">"
+                "  <backgroundColor>FFFFFF00</backgroundColor>"
+                "  <padding>8 8</padding>"
+                "  <imageColor>FFFFFFFF</imageColor>"
+                "</gridtile>"
+                "<gridtile name=\"selected\">"
+                "  <backgroundColor>" + Utils::String::toHexString(theme->Text.selectorColor) + "</backgroundColor>"
+                "</gridtile>"
+                "<text name=\"gridtile\">"
+                "  <color>" + Utils::String::toHexString(theme->Text.color) + "</color>"
+                "  <backgroundColor>00000000</backgroundColor>"
+                "  <fontPath>" + theme->TextSmall.font->getPath() + "</fontPath>"
+                "  <fontSize>" + std::to_string(sh) + "</fontSize>"
+                "  <alignment>center</alignment>"
+                "  <singleLineScroll>false</singleLineScroll>"
+                "  <size>1 0.30</size>"
+                "</text>"
+                "<text name=\"gridtile:selected\">"
+                "  <color>" + Utils::String::toHexString(theme->Text.selectedColor) + "</color>"
+                "</text>"
+                "<image name=\"gridtile.image\">"
+                "  <linearSmooth>true</linearSmooth>"
+                "</image>"
+                "</view>"
+                "</theme>";
+
+        mTheme = std::shared_ptr<ThemeData>(new ThemeData());
+        std::map<std::string, std::string> emptyMap;
+        mTheme->loadFile("imagebrowser", emptyMap, xml, false);
+        mGrid.applyTheme(mTheme, "grid", "gamegrid", 0);
+        mGrid.setCursorChangedCallback([&](const CursorState& /*state*/) { updateHelpPrompts(); });
+
+        if (startPath.empty() || !Utils::FileSystem::isDirectory(startPath))
+        {
+                mCurrentPath = Settings::getInstance()->getString("LastFileBrowserFolder");
+                if (mCurrentPath.empty() || !Utils::FileSystem::isDirectory(mCurrentPath))
+                        mCurrentPath = Paths::getScreenShotPath();
+                navigateTo(mCurrentPath);
+        }
+        else
+                navigateTo(startPath);
+}
+
+void GuiImageFileBrowser::navigateTo(const std::string& path)
+{
+        mCurrentPath = path;
+        mGrid.clear();
+        mGrid.onSizeChanged();
+
+        if (mCurrentPath != "\\" && mCurrentPath != "/" && !mCurrentPath.empty())
+                mGrid.add("..", ":/folder.svg", Utils::FileSystem::getParent(mCurrentPath));
+
+        auto files = Utils::FileSystem::getDirectoryFiles(mCurrentPath);
+        files.sort([](const Utils::FileSystem::FileInfo& file1, const Utils::FileSystem::FileInfo& file2) {
+                auto name1 = Utils::FileSystem::getFileName(file1.path);
+                auto name2 = Utils::FileSystem::getFileName(file2.path);
+                return Utils::String::compareIgnoreCase(name1, name2) < 0;
+        });
+
+        for (auto file : files)
+        {
+                if (file.hidden)
+                        continue;
+
+                if (file.directory)
+                {
+                        mGrid.add(Utils::FileSystem::getFileName(file.path), ":/folder.svg", file.path);
+                        continue;
+                }
+
+                std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(file.path));
+                if (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg")
+                        mGrid.add(Utils::FileSystem::getFileName(file.path), file.path, file.path);
+        }
+
+        if (!mSelectedFile.empty())
+                mGrid.setCursor(mSelectedFile);
+}
+
+void GuiImageFileBrowser::onSelected(const std::string& path)
+{
+        if (Utils::FileSystem::isDirectory(mCurrentPath) && Settings::getInstance()->setString("LastFileBrowserFolder", mCurrentPath))
+                Settings::getInstance()->saveFile();
+
+        if (mOkCallback)
+                mOkCallback(path);
+
+        delete this;
+}
+
+bool GuiImageFileBrowser::input(InputConfig* config, Input input)
+{
+        if (GuiComponent::input(config, input))
+                return true;
+
+        if (input.value != 0 && config->isMappedTo(BUTTON_BACK, input))
+        {
+                delete this;
+                return true;
+        }
+
+        if (input.value != 0 && config->isMappedTo("y", input))
+        {
+                if (mCurrentPath != "\\" && mCurrentPath != "/" && !mCurrentPath.empty())
+                        navigateTo(Utils::FileSystem::getParent(mCurrentPath));
+                return true;
+        }
+
+        if (input.value != 0 && config->isMappedTo(BUTTON_OK, input))
+        {
+                if (mGrid.size())
+                {
+                        std::string path = mGrid.getSelected();
+                        if (Utils::FileSystem::isDirectory(path))
+                                navigateTo(path);
+                        else
+                                onSelected(path);
+                }
+                return true;
+        }
+
+        return false;
+}
+
+std::vector<HelpPrompt> GuiImageFileBrowser::getHelpPrompts()
+{
+        std::vector<HelpPrompt> prompts;
+        prompts.push_back(HelpPrompt(BUTTON_OK, _("SELECT")));
+        prompts.push_back(HelpPrompt("y", _("PARENT FOLDER")));
+        prompts.push_back(HelpPrompt(BUTTON_BACK, _("CLOSE")));
+        return prompts;
 }

--- a/es-app/src/guis/GuiFileBrowser.h
+++ b/es-app/src/guis/GuiFileBrowser.h
@@ -2,7 +2,9 @@
 
 #include "GuiComponent.h"
 #include "components/MenuComponent.h"
+#include "components/ImageGridComponent.h"
 #include "ApiSystem.h"
+#include "ThemeData.h"
 
 template<typename T>
 class OptionListComponent;
@@ -36,5 +38,26 @@ private:
 	std::string mSelectedFile;
 	FileTypes   mTypes;
 
-	std::function<void(const std::string&)> mOkCallback;
+        std::function<void(const std::string&)> mOkCallback;
+};
+
+// A thumbnail oriented file browser using an image grid
+class GuiImageFileBrowser : public GuiComponent
+{
+public:
+        GuiImageFileBrowser(Window* window, const std::string startPath, const std::string selectedFile,
+                const std::function<void(const std::string&)>& okCallback = nullptr, const std::string& title = "");
+
+        bool input(InputConfig* config, Input input) override;
+        std::vector<HelpPrompt> getHelpPrompts() override;
+
+private:
+        void navigateTo(const std::string& path);
+        void onSelected(const std::string& path);
+
+        ImageGridComponent<std::string> mGrid;
+        std::shared_ptr<ThemeData> mTheme;
+        std::string mCurrentPath;
+        std::string mSelectedFile;
+        std::function<void(const std::string&)> mOkCallback;
 };

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -610,7 +610,7 @@ enable_customsplashimage->setState(customSplashImageEnabled);
 s->addWithLabel(_("ENABLE CUSTOM SPLASH IMAGE"), enable_customsplashimage);
 
 // File picker for custom splash image
-s->addFileBrowser(_("CUSTOM SPLASH IMAGE"), "ee_customsplashimage", GuiFileBrowser::IMAGES);
+        s->addFileBrowser(_("CUSTOM SPLASH IMAGE"), "ee_customsplashimage", GuiFileBrowser::IMAGES, false, true);
 
 // Custom splash video
 auto enable_customsplashvideo = std::make_shared<SwitchComponent>(mWindow);

--- a/es-app/src/guis/GuiSettings.cpp
+++ b/es-app/src/guis/GuiSettings.cpp
@@ -230,7 +230,7 @@ void GuiSettings::addInputTextRow(const std::string& title, const std::string& s
 	addRow(row);
 }
 
-void GuiSettings::addFileBrowser(const std::string& title, const std::string& settingsID, GuiFileBrowser::FileTypes type, bool storeInSettings)
+void GuiSettings::addFileBrowser(const std::string& title, const std::string& settingsID, GuiFileBrowser::FileTypes type, bool storeInSettings, bool useThumbnailBrowser)
 {
 	Window* window = mWindow;
 
@@ -270,11 +270,14 @@ void GuiSettings::addFileBrowser(const std::string& title, const std::string& se
 			SystemConf::getInstance()->set(localSettingsID, newVal);
 	};
 
-	row.makeAcceptInputHandler([window, title, type, ed, updateVal]
-	{
-		auto parent = Utils::FileSystem::getParent(ed->getValue());
-		window->pushGui(new GuiFileBrowser(window, parent, ed->getValue(), type, updateVal, title));
-	});
+        row.makeAcceptInputHandler([window, title, type, ed, updateVal, useThumbnailBrowser]
+        {
+                auto parent = Utils::FileSystem::getParent(ed->getValue());
+                if (useThumbnailBrowser && type == GuiFileBrowser::IMAGES)
+                        window->pushGui(new GuiImageFileBrowser(window, parent, ed->getValue(), updateVal, title));
+                else
+                        window->pushGui(new GuiFileBrowser(window, parent, ed->getValue(), type, updateVal, title));
+        });
 
 	ed->setValue(value);
 

--- a/es-app/src/guis/GuiSettings.h
+++ b/es-app/src/guis/GuiSettings.h
@@ -86,7 +86,7 @@ public:
 	}
 	
 	void addInputTextRow(const std::string& title, const std::string& settingsID, bool password, bool storeInSettings = false, const std::function<void(Window*, std::string/*title*/, std::string /*value*/, const std::function<void(std::string)>& onsave)>& customEditor = nullptr);
-	void addFileBrowser(const std::string& title, const std::string& settingsID, GuiFileBrowser::FileTypes type, bool storeInSettings = false);
+        void addFileBrowser(const std::string& title, const std::string& settingsID, GuiFileBrowser::FileTypes type, bool storeInSettings = false, bool useThumbnailBrowser = false);
 	
 	std::shared_ptr<SwitchComponent> addSwitch(const std::string& title, const std::string& settingsID, bool storeInSettings, const std::function<void()>& onChanged = nullptr) { return addSwitch(title, "", settingsID, storeInSettings, onChanged); }
 	std::shared_ptr<SwitchComponent> addSwitch(const std::string& title, const std::string& description, const std::string& settingsID, bool storeInSettings, const std::function<void()>& onChanged);


### PR DESCRIPTION
## Summary
- add `GuiImageFileBrowser` that presents directories and image files in an image grid
- allow `GuiSettings::addFileBrowser` to open thumbnail browser
- use thumbnails when choosing custom splash image

## Testing
- `cmake -B build -S .` *(failed: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b6793568832089ae112b03bcef73