### PR TITLE
Add image previews to file browser

### DIFF
--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -11,6 +11,7 @@
 #include "GuiLoading.h"
 #include "guis/GuiMsgBox.h"
 #include <cstring>
+#include <algorithm>
 #include "SystemConf.h"
 #include "Paths.h"
 
@@ -25,16 +26,36 @@
 
 
 
-GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types, const std::function<void(const std::string&)>& okCallback, const std::string& title)
-	: GuiComponent(window), mMenu(window, title.empty() ? _("FILE BROWSER") : title)
+GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types, const std::function<void(const std::string&)>& okCallback, const std::string& title, bool showPreview)
+        : GuiComponent(window), mMenu(window, title.empty() ? _("FILE BROWSER") : title)
 {
-	setTag("popup");
+        setTag("popup");
 
-	mTypes = types;
-	mSelectedFile = Utils::FileSystem::getCanonicalPath(selectedFile);
-	mOkCallback = okCallback;
+        mTypes = types;
+        mSelectedFile = Utils::FileSystem::getCanonicalPath(selectedFile);
+        mOkCallback = okCallback;
 
-	addChild(&mMenu);
+        addChild(&mMenu);
+
+        if (showPreview && (mTypes & FileTypes::IMAGES) == FileTypes::IMAGES)
+        {
+                mPreview = std::make_unique<ImageComponent>(window);
+                addChild(mPreview.get());
+
+                mMenu.getList()->setCursorChangedCallback([this](CursorState state)
+                {
+                        if (state == CURSOR_STOPPED && mPreview)
+                        {
+                                auto path = mMenu.getSelected();
+                                auto ext = Utils::FileSystem::getExtension(path);
+                                if (!path.empty() && !Utils::FileSystem::isDirectory(path) &&
+                                        (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg"))
+                                        mPreview->setImage(path);
+                                else
+                                        mPreview->setImage("");
+                        }
+                });
+        }
 
 	if (mOkCallback != nullptr)
 	{
@@ -46,16 +67,19 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 
     mMenu.addButton(_("BACK"), "back", [&] { delete this; });
 
-	if (startPath.empty() || !Utils::FileSystem::isDirectory(startPath))
-	{
-		mCurrentPath = Settings::getInstance()->getString("LastFileBrowserFolder");
-		if (mCurrentPath.empty() || !Utils::FileSystem::isDirectory(mCurrentPath))
-			mCurrentPath = Paths::getScreenShotPath();
+        if (startPath.empty() || !Utils::FileSystem::isDirectory(startPath))
+        {
+                mCurrentPath = Settings::getInstance()->getString("LastFileBrowserFolder");
+                if (mCurrentPath.empty() || !Utils::FileSystem::isDirectory(mCurrentPath))
+                        mCurrentPath = Paths::getScreenShotPath();
 
-		navigateTo(mCurrentPath);
-	}
-	else
-		navigateTo(startPath);
+                navigateTo(mCurrentPath);
+        }
+        else
+                navigateTo(startPath);
+
+        if (mPreview && mMenu.getList()->getCursorChangedCallback())
+                mMenu.getList()->getCursorChangedCallback()(CURSOR_STOPPED);
 }
 
 void GuiFileBrowser::navigateTo(const std::string path)
@@ -141,18 +165,40 @@ void GuiFileBrowser::navigateTo(const std::string path)
 		}
 	}
 
-	centerWindow();	
+        centerWindow();
+
+        if (mPreview && mMenu.getList()->getCursorChangedCallback())
+                mMenu.getList()->getCursorChangedCallback()(CURSOR_STOPPED);
 }
 
 void GuiFileBrowser::centerWindow()
 {
-	if (Renderer::ScreenSettings::fullScreenMenus())
-		mMenu.setSize(Renderer::getScreenWidth(), Renderer::getScreenHeight());
-	else
-	{
-		mMenu.setSize(mMenu.getSize().x(), Renderer::getScreenHeight() * 0.875f);
-		mMenu.setPosition((Renderer::getScreenWidth() - mMenu.getSize().x()) / 2, (Renderer::getScreenHeight() - mMenu.getSize().y()) / 2);
-	}
+        float height = Renderer::ScreenSettings::fullScreenMenus() ? Renderer::getScreenHeight() : Renderer::getScreenHeight() * 0.875f;
+
+        if (mPreview)
+        {
+                float menuWidth = mMenu.getSize().x();
+                float previewWidth = std::max(0.0f, Renderer::getScreenWidth() - menuWidth);
+                float posX = (Renderer::getScreenWidth() - (menuWidth + previewWidth)) / 2;
+                float posY = (Renderer::getScreenHeight() - height) / 2;
+
+                mMenu.setSize(menuWidth, height);
+                mMenu.setPosition(posX, posY);
+
+                mPreview->setMaxSize(previewWidth, height);
+                mPreview->setPosition(posX + menuWidth, posY);
+        }
+        else
+        {
+                if (Renderer::ScreenSettings::fullScreenMenus())
+                        mMenu.setSize(Renderer::getScreenWidth(), Renderer::getScreenHeight());
+                else
+                {
+                        mMenu.setSize(mMenu.getSize().x(), height);
+                        mMenu.setPosition((Renderer::getScreenWidth() - mMenu.getSize().x()) / 2,
+                                (Renderer::getScreenHeight() - mMenu.getSize().y()) / 2);
+                }
+        }
 }
 
 bool GuiFileBrowser::input(InputConfig* config, Input input)

--- a/es-app/src/guis/GuiFileBrowser.h
+++ b/es-app/src/guis/GuiFileBrowser.h
@@ -3,6 +3,8 @@
 #include "GuiComponent.h"
 #include "components/MenuComponent.h"
 #include "ApiSystem.h"
+#include "components/ImageComponent.h"
+#include <memory>
 
 template<typename T>
 class OptionListComponent;
@@ -20,7 +22,7 @@ public:
 		ALL = 255
 	};
 
-	GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types = FileTypes::IMAGES, const std::function<void(const std::string&)>& okCallback = nullptr, const std::string& title = "");
+        GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types = FileTypes::IMAGES, const std::function<void(const std::string&)>& okCallback = nullptr, const std::string& title = "", bool showPreview = false);
 
 	bool input(InputConfig* config, Input input) override;
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
@@ -30,11 +32,12 @@ private:
 	void navigateTo(const std::string path);
 	void centerWindow();
 
-	MenuComponent mMenu;	
+        MenuComponent mMenu;
+        std::unique_ptr<ImageComponent> mPreview;
 
-	std::string mCurrentPath;
-	std::string mSelectedFile;
-	FileTypes   mTypes;
+        std::string mCurrentPath;
+        std::string mSelectedFile;
+        FileTypes   mTypes;
 
-	std::function<void(const std::string&)> mOkCallback;
+        std::function<void(const std::string&)> mOkCallback;
 };

--- a/es-app/src/guis/GuiMenu.cpp
+++ b/es-app/src/guis/GuiMenu.cpp
@@ -612,7 +612,7 @@ enable_customsplashimage->setState(customSplashImageEnabled);
 s->addWithLabel(_("ENABLE CUSTOM SPLASH IMAGE"), enable_customsplashimage);
 
 // File picker for custom splash image
-s->addFileBrowser(_("CUSTOM SPLASH IMAGE"), "ee_customsplashimage", GuiFileBrowser::IMAGES);
+        s->addFileBrowser(_("CUSTOM SPLASH IMAGE"), "ee_customsplashimage", GuiFileBrowser::IMAGES, false, true);
 
 // Custom splash video
 auto enable_customsplashvideo = std::make_shared<SwitchComponent>(mWindow);
@@ -681,7 +681,7 @@ enable_customexitsplashimage->setState(customExitSplashImageEnabled);
 s->addWithLabel(_("ENABLE CUSTOM EXIT-SPLASH IMAGE"), enable_customexitsplashimage);
 
 // File picker for custom splash image
-s->addFileBrowser(_("CUSTOM EXIT-SPLASH IMAGE"), "ee_customexitsplashimage", GuiFileBrowser::IMAGES);
+        s->addFileBrowser(_("CUSTOM EXIT-SPLASH IMAGE"), "ee_customexitsplashimage", GuiFileBrowser::IMAGES, false, true);
 
 
 // Custom exit-splash video

--- a/es-app/src/guis/GuiSettings.cpp
+++ b/es-app/src/guis/GuiSettings.cpp
@@ -230,7 +230,7 @@ void GuiSettings::addInputTextRow(const std::string& title, const std::string& s
 	addRow(row);
 }
 
-void GuiSettings::addFileBrowser(const std::string& title, const std::string& settingsID, GuiFileBrowser::FileTypes type, bool storeInSettings)
+void GuiSettings::addFileBrowser(const std::string& title, const std::string& settingsID, GuiFileBrowser::FileTypes type, bool storeInSettings, bool showPreview)
 {
 	Window* window = mWindow;
 
@@ -270,11 +270,11 @@ void GuiSettings::addFileBrowser(const std::string& title, const std::string& se
 			SystemConf::getInstance()->set(localSettingsID, newVal);
 	};
 
-	row.makeAcceptInputHandler([window, title, type, ed, updateVal]
-	{
-		auto parent = Utils::FileSystem::getParent(ed->getValue());
-		window->pushGui(new GuiFileBrowser(window, parent, ed->getValue(), type, updateVal, title));
-	});
+        row.makeAcceptInputHandler([window, title, type, ed, updateVal, showPreview]
+        {
+                auto parent = Utils::FileSystem::getParent(ed->getValue());
+                window->pushGui(new GuiFileBrowser(window, parent, ed->getValue(), type, updateVal, title, showPreview));
+        });
 
 	ed->setValue(value);
 

--- a/es-app/src/guis/GuiSettings.h
+++ b/es-app/src/guis/GuiSettings.h
@@ -72,7 +72,7 @@ public:
 	}
 	
 	void addInputTextRow(const std::string& title, const std::string& settingsID, bool password, bool storeInSettings = false, const std::function<void(Window*, std::string/*title*/, std::string /*value*/, const std::function<void(std::string)>& onsave)>& customEditor = nullptr);
-	void addFileBrowser(const std::string& title, const std::string& settingsID, GuiFileBrowser::FileTypes type, bool storeInSettings = false);
+        void addFileBrowser(const std::string& title, const std::string& settingsID, GuiFileBrowser::FileTypes type, bool storeInSettings = false, bool showPreview = false);
 	
 	std::shared_ptr<SwitchComponent> addSwitch(const std::string& title, const std::string& settingsID, bool storeInSettings, const std::function<void()>& onChanged = nullptr) { return addSwitch(title, "", settingsID, storeInSettings, onChanged); }
 	std::shared_ptr<SwitchComponent> addSwitch(const std::string& title, const std::string& description, const std::string& settingsID, bool storeInSettings, const std::function<void()>& onChanged);


### PR DESCRIPTION
## Summary
- extend GuiSettings::addFileBrowser with a showPreview flag
- allow GuiFileBrowser to display a preview image beside the menu
- enable image previews for splash image selectors in the main menu

## Testing
- `cmake .` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b9bed0948320a37fff7f8d0f8821