### PR TITLE
Clear file browser callback before deletion

### DIFF
--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -65,7 +65,11 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 		});
 	}
 
-    mMenu.addButton(_("BACK"), "back", [&] { delete this; });
+        mMenu.addButton(_("BACK"), "back", [this]
+        {
+                mMenu.getList()->setCursorChangedCallback(nullptr);
+                delete this;
+        });
 
         if (startPath.empty() || !Utils::FileSystem::isDirectory(startPath))
         {
@@ -80,6 +84,12 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 
         if (mPreview && mMenu.getList()->getCursorChangedCallback())
                 mMenu.getList()->getCursorChangedCallback()(CURSOR_STOPPED);
+}
+
+GuiFileBrowser::~GuiFileBrowser()
+{
+        mMenu.getList()->setCursorChangedCallback(nullptr);
+        mPreview.reset();
 }
 
 void GuiFileBrowser::navigateTo(const std::string path)
@@ -220,11 +230,12 @@ bool GuiFileBrowser::input(InputConfig* config, Input input)
 		return true;
 	}
 
-	if (input.value != 0 && config->isMappedTo(BUTTON_BACK, input))
-	{
-		delete this;
-		return true;
-	}
+        if (input.value != 0 && config->isMappedTo(BUTTON_BACK, input))
+        {
+                mMenu.getList()->setCursorChangedCallback(nullptr);
+                delete this;
+                return true;
+        }
 
 	if (config->isMappedTo("start", input) && input.value != 0)
 	{		
@@ -276,8 +287,9 @@ void GuiFileBrowser::onOk(const std::string& path)
 	if (Utils::FileSystem::isDirectory(mCurrentPath) && Settings::getInstance()->setString("LastFileBrowserFolder", mCurrentPath))
 		Settings::getInstance()->saveFile();
 
-	if (mOkCallback)
-		mOkCallback(path);
+        if (mOkCallback)
+                mOkCallback(path);
 
-	delete this;
+        mMenu.getList()->setCursorChangedCallback(nullptr);
+        delete this;
 }

--- a/es-app/src/guis/GuiFileBrowser.h
+++ b/es-app/src/guis/GuiFileBrowser.h
@@ -22,10 +22,11 @@ public:
 		ALL = 255
 	};
 
-        GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types = FileTypes::IMAGES, const std::function<void(const std::string&)>& okCallback = nullptr, const std::string& title = "", bool showPreview = false);
+GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types = FileTypes::IMAGES, const std::function<void(const std::string&)>& okCallback = nullptr, const std::string& title = "", bool showPreview = false);
+~GuiFileBrowser() override;
 
-	bool input(InputConfig* config, Input input) override;
-	virtual std::vector<HelpPrompt> getHelpPrompts() override;
+bool input(InputConfig* config, Input input) override;
+virtual std::vector<HelpPrompt> getHelpPrompts() override;
 
 private:
 	void onOk(const std::string& path);


### PR DESCRIPTION
## Summary
- Add `~GuiFileBrowser` to release preview resources and clear cursor callback
- Ensure BACK and OK paths clear cursor callback before destroying GuiFileBrowser

## Testing
- `cmake ..` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68c26c9674b483208fea877053946102