### PR TITLE
Use bit flags for GuiFileBrowser FileTypes

### DIFF
--- a/es-app/src/guis/GuiFileBrowser.h
+++ b/es-app/src/guis/GuiFileBrowser.h
@@ -14,12 +14,12 @@ class GuiFileBrowser : public GuiComponent
 public:
 	enum FileTypes
 	{
-		IMAGES = 1,
-		MANUALS = 2,
-		VIDEO = 3,
-		DIRECTORY = 4,
-		AUDIO = 5,
-		ALL = 255
+		IMAGES = 1 << 0,
+		MANUALS = 1 << 1,
+		VIDEO = 1 << 2,
+		DIRECTORY = 1 << 3,
+		AUDIO = 1 << 4,
+		ALL = 0x1F
 	};
 
         GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types = FileTypes::IMAGES, const std::function<void(const std::string&)>& okCallback = nullptr, const std::string& title = "", bool showPreview = false);


### PR DESCRIPTION
## Summary
- adjust GuiFileBrowser's FileTypes to use power-of-two bit flags

## Testing
- `cmake -S . -B build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68c26c98835c83208b943276f6cac153