### PR TITLE
Manage video preview lifecycle in file browser

### DIFF
--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -3,6 +3,7 @@
 #include "ApiSystem.h"
 #include "components/OptionListComponent.h"
 #include "components/ImageComponent.h"
+#include "components/VideoVlcComponent.h"
 #include "utils/StringUtil.h"
 #include "guis/GuiSettings.h"
 #include "views/ViewController.h"
@@ -28,7 +29,7 @@
 
 
 GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types, const std::function<void(const std::string&)>& okCallback, const std::string& title)
-	: GuiComponent(window), mMenu(window, title.empty() ? _("FILE BROWSER") : title)
+        : GuiComponent(window), mMenu(window, title.empty() ? _("FILE BROWSER") : title)
 {
 	setTag("popup");
 
@@ -42,12 +43,20 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
        mPreview->setVisible(false);
        addChild(mPreview.get());
 
+       mVideoPreview = std::shared_ptr<VideoComponent>(new VideoVlcComponent(window));
+       mVideoPreview->setVisible(false);
+       addChild(mVideoPreview.get());
+
        mMenu.getList()->setCursorChangedCallback([this](CursorState state)
        {
                if (mMenu.size() == 0)
                {
                        mPreview->setImage("");
                        mPreview->setVisible(false);
+
+                       mVideoPreview->onHide();
+                       mVideoPreview->setVideo("");
+                       mVideoPreview->setVisible(false);
                        return;
                }
 
@@ -57,11 +66,28 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
                {
                        mPreview->setImage(path);
                        mPreview->setVisible(true);
+
+                       mVideoPreview->onHide();
+                       mVideoPreview->setVideo("");
+                       mVideoPreview->setVisible(false);
+               }
+               else if (ext == ".mp4" || ext == ".avi" || ext == ".mkv" || ext == ".webm")
+               {
+                       mPreview->setImage("");
+                       mPreview->setVisible(false);
+
+                       mVideoPreview->setVideo(path);
+                       mVideoPreview->setVisible(true);
+                       mVideoPreview->onShow();
                }
                else
                {
                        mPreview->setImage("");
                        mPreview->setVisible(false);
+
+                       mVideoPreview->onHide();
+                       mVideoPreview->setVideo("");
+                       mVideoPreview->setVisible(false);
                }
        });
 
@@ -87,14 +113,24 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 		navigateTo(startPath);
 }
 
+GuiFileBrowser::~GuiFileBrowser()
+{
+        mVideoPreview->onHide();
+        mVideoPreview->setVideo("");
+}
+
 void GuiFileBrowser::navigateTo(const std::string path)
 {
-	mCurrentPath = path;
+        mVideoPreview->onHide();
+        mVideoPreview->setVideo("");
+        mVideoPreview->setVisible(false);
 
-	auto theme = ThemeData::getMenuTheme();
+        mCurrentPath = path;
 
-	mMenu.clear();
-	mMenu.setSubTitle(mCurrentPath);
+        auto theme = ThemeData::getMenuTheme();
+
+        mMenu.clear();
+        mMenu.setSubTitle(mCurrentPath);
 
 	auto files = Utils::FileSystem::getDirectoryFiles(mCurrentPath);
 
@@ -194,6 +230,9 @@ void GuiFileBrowser::centerWindow()
 
         mPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
         mPreview->setMaxSize(previewWidth, mMenu.getSize().y());
+
+        mVideoPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
+        mVideoPreview->setMaxSize(previewWidth, mMenu.getSize().y());
 }
 
 bool GuiFileBrowser::input(InputConfig* config, Input input)
@@ -268,8 +307,12 @@ std::vector<HelpPrompt> GuiFileBrowser::getHelpPrompts()
 
 void GuiFileBrowser::onOk(const std::string& path)
 {
-	if (Utils::FileSystem::isDirectory(mCurrentPath) && Settings::getInstance()->setString("LastFileBrowserFolder", mCurrentPath))
-		Settings::getInstance()->saveFile();
+        mVideoPreview->onHide();
+        mVideoPreview->setVideo("");
+        mVideoPreview->setVisible(false);
+
+        if (Utils::FileSystem::isDirectory(mCurrentPath) && Settings::getInstance()->setString("LastFileBrowserFolder", mCurrentPath))
+                Settings::getInstance()->saveFile();
 
 	if (mOkCallback)
 		mOkCallback(path);

--- a/es-app/src/guis/GuiFileBrowser.h
+++ b/es-app/src/guis/GuiFileBrowser.h
@@ -3,6 +3,7 @@
 #include "GuiComponent.h"
 #include "components/MenuComponent.h"
 #include "ApiSystem.h"
+#include "components/VideoComponent.h"
 
 template<typename T>
 class OptionListComponent;
@@ -22,10 +23,11 @@ public:
 		ALL = 255
 	};
 
-	GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types = FileTypes::IMAGES, const std::function<void(const std::string&)>& okCallback = nullptr, const std::string& title = "");
+        GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types = FileTypes::IMAGES, const std::function<void(const std::string&)>& okCallback = nullptr, const std::string& title = "");
+        ~GuiFileBrowser();
 
-	bool input(InputConfig* config, Input input) override;
-	virtual std::vector<HelpPrompt> getHelpPrompts() override;
+        bool input(InputConfig* config, Input input) override;
+        virtual std::vector<HelpPrompt> getHelpPrompts() override;
 
 private:
         void onOk(const std::string& path);
@@ -38,6 +40,7 @@ private:
         std::string mSelectedFile;
         FileTypes   mTypes;
         std::shared_ptr<ImageComponent> mPreview;
+        std::shared_ptr<VideoComponent> mVideoPreview;
 
         std::function<void(const std::string&)> mOkCallback;
 };


### PR DESCRIPTION
## Summary
- add dedicated video preview component to file browser
- start video playback on show and stop on hide in cursor callbacks
- stop video preview when navigating away or confirming a selection

## Testing
- `cmake ..` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d09021a483208ef7ace05f01a2c7