### PR TITLE
Use bit masks for GuiFileBrowser file types

### DIFF
--- a/es-app/src/guis/GuiFileBrowser.h
+++ b/es-app/src/guis/GuiFileBrowser.h
@@ -10,15 +10,15 @@ class OptionListComponent;
 class GuiFileBrowser : public GuiComponent
 {
 public:
-	enum FileTypes
-	{
-		IMAGES = 1,
-		MANUALS = 2,
-		VIDEO = 3,
-		DIRECTORY = 4,
-		AUDIO = 5,
-		ALL = 255
-	};
+        enum FileTypes
+        {
+               IMAGES    = 1 << 0,
+               MANUALS   = 1 << 1,
+               VIDEO     = 1 << 2,
+               DIRECTORY = 1 << 3,
+               AUDIO     = 1 << 4,
+               ALL       = 0xFF
+        };
 
 	GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types = FileTypes::IMAGES, const std::function<void(const std::string&)>& okCallback = nullptr, const std::string& title = "");
 


### PR DESCRIPTION
## Summary
- redefine GuiFileBrowser::FileTypes values as bit masks to allow flag combinations

## Testing
- `cmake ..` (fails: Could NOT find OpenGL)


------
https://chatgpt.com/codex/tasks/task_e_68c33b5e2cf4832080643e95f759a709