### PR TITLE
Add video preview to file browser

### DIFF
--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -1,7 +1,6 @@
 #include "guis/GuiFileBrowser.h"
 #include "ApiSystem.h"
 #include "components/OptionListComponent.h"
-#include "components/ImageComponent.h"
 #ifdef _RPI_
 #include "components/VideoPlayerComponent.h"
 #endif
@@ -41,74 +40,63 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 
 	addChild(&mMenu);
 
-	// Separate components for images and videos
-	mImage = std::shared_ptr<ImageComponent>(new ImageComponent(window));
-	mImage->setVisible(false);
-	addChild(mImage.get());
-
+       // Single preview component capable of showing images or videos
 #ifdef _RPI_
-	if (Settings::getInstance()->getBool("VideoOmxPlayer"))
-	mVideo = std::shared_ptr<VideoComponent>(new VideoPlayerComponent(window, ""));
-	else
+       if (Settings::getInstance()->getBool("VideoOmxPlayer"))
+               mPreview = std::shared_ptr<VideoComponent>(new VideoPlayerComponent(window, ""));
+       else
 #endif
-	mVideo = std::shared_ptr<VideoComponent>(new VideoVlcComponent(window));
+               mPreview = std::shared_ptr<VideoComponent>(new VideoVlcComponent(window));
 
-	mVideo->setPlayAudio(false);
-	mVideo->setStartDelay(0);
-	mVideo->setVisible(false);
-	addChild(mVideo.get());
+       mPreview->setPlayAudio(false);
+       mPreview->setStartDelay(0);
+       mPreview->setVisible(false);
+       mPreview->setSnapshotSource(IMAGE);
+       addChild(mPreview.get());
 
 	mMenu.getList()->setCursorChangedCallback([this](CursorState state)
 	{
-	if (mMenu.size() == 0)
-	{
-		       mImage->setImage("");
-		       mImage->setVisible(false);
-		       mVideo->setVideo("");
-		       mVideo->setVisible(false);
-		       mVideo->onHide();
-		       return;
-	}
+       if (mMenu.size() == 0)
+       {
+               mPreview->setVideo("");
+               mPreview->setImage("");
+               mPreview->setVisible(false);
+               mPreview->onHide();
+               return;
+       }
 
-	std::string path = mMenu.getSelected();
-	std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(path));
-	if (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg")
-	{
-		       mVideo->setVideo("");
-		       mVideo->setVisible(false);
-		       mVideo->onHide();
+       std::string path = mMenu.getSelected();
+       std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(path));
 
-		       mImage->setImage(path);
-		       mImage->setVisible(true);
-	}
-	else if (ext == ".mp4" || ext == ".avi" || ext == ".mkv" || ext == ".webm")
-	{
-		       mImage->setImage("");
-		       mImage->setVisible(false);
-
-		       if (!mVideo->setVideo(path))
-		       {
-			       mImage->setImage(path);
-			       mImage->setVisible(true);
-			       mVideo->setVideo("");
-			       mVideo->setVisible(false);
-			       mVideo->onHide();
-		       }
-		       else
-		       {
-			       mVideo->setVisible(true);
-			       mVideo->onShow();
-		       }
-	}
-	else
-	{
-		       mImage->setImage("");
-		       mImage->setVisible(false);
-		       mVideo->setVideo("");
-		       mVideo->setVisible(false);
-		       mVideo->onHide();
-	}
-	});
+       if (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg")
+       {
+               mPreview->setVideo("");
+               mPreview->setImage(path);
+               mPreview->setVisible(true);
+       }
+       else if (ext == ".mp4" || ext == ".avi" || ext == ".mkv" || ext == ".webm")
+       {
+               mPreview->setImage("");
+               if (mPreview->setVideo(path))
+               {
+                       mPreview->setVisible(true);
+                       mPreview->onShow();
+               }
+               else
+               {
+                       mPreview->setVideo("");
+                       mPreview->setImage(path);
+                       mPreview->setVisible(true);
+               }
+       }
+       else
+       {
+               mPreview->setVideo("");
+               mPreview->setImage("");
+               mPreview->setVisible(false);
+               mPreview->onHide();
+       }
+       });
 
 	if (mOkCallback != nullptr)
 	{
@@ -136,12 +124,11 @@ void GuiFileBrowser::navigateTo(const std::string path)
 {
 	mCurrentPath = path;
 
-	// Reset previews when changing directories
-	mImage->setImage("");
-	mImage->setVisible(false);
-	mVideo->setVideo("");
-	mVideo->setVisible(false);
-	mVideo->onHide();
+       // Reset preview when changing directories
+       mPreview->setVideo("");
+       mPreview->setImage("");
+       mPreview->setVisible(false);
+       mPreview->onHide();
 
 	auto theme = ThemeData::getMenuTheme();
 
@@ -244,12 +231,10 @@ void GuiFileBrowser::centerWindow()
 		mMenu.setPosition((Renderer::getScreenWidth() - (menuWidth + previewWidth)) / 2, (Renderer::getScreenHeight() - mMenu.getSize().y()) / 2);
 	}
 
-	float previewX = mMenu.getPosition().x() + mMenu.getSize().x();
-	float previewY = mMenu.getPosition().y();
-	mImage->setPosition(previewX, previewY);
-	mImage->setMaxSize(previewWidth, mMenu.getSize().y());
-	mVideo->setPosition(previewX, previewY);
-	mVideo->setMaxSize(previewWidth, mMenu.getSize().y());
+       float previewX = mMenu.getPosition().x() + mMenu.getSize().x();
+       float previewY = mMenu.getPosition().y();
+       mPreview->setPosition(previewX, previewY);
+       mPreview->setMaxSize(previewWidth, mMenu.getSize().y());
 }
 
 bool GuiFileBrowser::input(InputConfig* config, Input input)

--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -1,7 +1,7 @@
 #include "guis/GuiFileBrowser.h"
-
 #include "ApiSystem.h"
 #include "components/OptionListComponent.h"
+#include "components/ImageComponent.h"
 #ifdef _RPI_
 #include "components/VideoPlayerComponent.h"
 #endif
@@ -41,49 +41,62 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 
         addChild(&mMenu);
 
-        // Create preview component capable of images and videos
-#ifdef _RPI_
-        if (Settings::getInstance()->getBool("VideoOmxPlayer"))
-                mPreview = std::shared_ptr<VideoComponent>(new VideoPlayerComponent(window, ""));
-        else
-#endif
-                mPreview = std::shared_ptr<VideoComponent>(new VideoVlcComponent(window));
+       mImagePreview = std::make_shared<ImageComponent>(window);
+       mImagePreview->setVisible(false);
+       addChild(mImagePreview.get());
 
-        mPreview->setPlayAudio(false);
-        mPreview->setVisible(false);
-        mPreview->setStartDelay(0);
-        addChild(mPreview.get());
+#ifdef _RPI_
+       if (Settings::getInstance()->getBool("VideoOmxPlayer"))
+               mVideoPreview = std::shared_ptr<VideoComponent>(new VideoPlayerComponent(window, ""));
+       else
+#endif
+               mVideoPreview = std::shared_ptr<VideoComponent>(new VideoVlcComponent(window));
+
+       mVideoPreview->setPlayAudio(false);
+       mVideoPreview->setVisible(false);
+       mVideoPreview->setStartDelay(0);
+       addChild(mVideoPreview.get());
 
         mMenu.getList()->setCursorChangedCallback([this](CursorState state)
         {
-                if (mMenu.size() == 0)
-                {
-                        mPreview->setVideo("");
-                        mPreview->setImage("");
-                        mPreview->setVisible(false);
-                        return;
-                }
+               if (mMenu.size() == 0)
+               {
+                       mImagePreview->setImage("");
+                       mImagePreview->setVisible(false);
+                       mVideoPreview->setVideo("");
+                       mVideoPreview->setImage("");
+                       mVideoPreview->setVisible(false);
+                       return;
+               }
 
-                std::string path = mMenu.getSelected();
-                std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(path));
-                if (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg")
-                {
-                        mPreview->setVideo("");
-                        mPreview->setImage(path);
-                        mPreview->setVisible(true);
-                }
-                else if (ext == ".mp4" || ext == ".avi" || ext == ".mkv" || ext == ".webm")
-                {
-                        mPreview->setImage("");
-                        mPreview->setVideo(path);
-                        mPreview->setVisible(true);
-                }
-                else
-                {
-                        mPreview->setVideo("");
-                        mPreview->setImage("");
-                        mPreview->setVisible(false);
-                }
+               std::string path = mMenu.getSelected();
+               std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(path));
+               if (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg")
+               {
+                       mVideoPreview->setVideo("");
+                       mVideoPreview->setImage("");
+                       mVideoPreview->setVisible(false);
+
+                       mImagePreview->setImage(path);
+                       mImagePreview->setVisible(true);
+               }
+               else if (ext == ".mp4" || ext == ".avi" || ext == ".mkv" || ext == ".webm")
+               {
+                       mImagePreview->setImage("");
+                       mImagePreview->setVisible(false);
+
+                       mVideoPreview->setImage("");
+                       mVideoPreview->setVideo(path);
+                       mVideoPreview->setVisible(true);
+               }
+               else
+               {
+                       mImagePreview->setImage("");
+                       mImagePreview->setVisible(false);
+                       mVideoPreview->setVideo("");
+                       mVideoPreview->setImage("");
+                       mVideoPreview->setVisible(false);
+               }
         });
 
 	if (mOkCallback != nullptr)
@@ -112,10 +125,12 @@ void GuiFileBrowser::navigateTo(const std::string path)
 {
 	mCurrentPath = path;
 
-        // Reset preview when changing directories
-        mPreview->setVideo("");
-        mPreview->setImage("");
-        mPreview->setVisible(false);
+       // Reset previews when changing directories
+       mImagePreview->setImage("");
+       mImagePreview->setVisible(false);
+       mVideoPreview->setVideo("");
+       mVideoPreview->setImage("");
+       mVideoPreview->setVisible(false);
 
 	auto theme = ThemeData::getMenuTheme();
 
@@ -218,8 +233,11 @@ void GuiFileBrowser::centerWindow()
 		mMenu.setPosition((Renderer::getScreenWidth() - (menuWidth + previewWidth)) / 2, (Renderer::getScreenHeight() - mMenu.getSize().y()) / 2);
 	}
 
-        mPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
-        mPreview->setMaxSize(previewWidth, mMenu.getSize().y());
+       mImagePreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
+       mImagePreview->setMaxSize(previewWidth, mMenu.getSize().y());
+
+       mVideoPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
+       mVideoPreview->setMaxSize(previewWidth, mMenu.getSize().y());
 }
 
 bool GuiFileBrowser::input(InputConfig* config, Input input)

--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -2,7 +2,10 @@
 
 #include "ApiSystem.h"
 #include "components/OptionListComponent.h"
-#include "components/ImageComponent.h"
+#ifdef _RPI_
+#include "components/VideoPlayerComponent.h"
+#endif
+#include "components/VideoVlcComponent.h"
 #include "utils/StringUtil.h"
 #include "guis/GuiSettings.h"
 #include "views/ViewController.h"
@@ -36,34 +39,51 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 	mSelectedFile = Utils::FileSystem::getCanonicalPath(selectedFile);
 	mOkCallback = okCallback;
 
-        addChild(&mMenu);
+	addChild(&mMenu);
 
-        mPreview = std::make_shared<ImageComponent>(window);
-       mPreview->setVisible(false);
-       addChild(mPreview.get());
+	// Create video component for preview and disable audio
+#ifdef _RPI_
+	if (Settings::getInstance()->getBool("VideoOmxPlayer"))
+		mPreview = std::shared_ptr<VideoComponent>(new VideoPlayerComponent(window, ""));
+	else
+#endif
+		mPreview = std::shared_ptr<VideoComponent>(new VideoVlcComponent(window));
 
-       mMenu.getList()->setCursorChangedCallback([this](CursorState state)
-       {
-               if (mMenu.size() == 0)
-               {
-                       mPreview->setImage("");
-                       mPreview->setVisible(false);
-                       return;
-               }
+	mPreview->setPlayAudio(false);
+	mPreview->setVisible(false);
+	addChild(mPreview.get());
 
-               std::string path = mMenu.getSelected();
-               std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(path));
-               if (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg")
-               {
-                       mPreview->setImage(path);
-                       mPreview->setVisible(true);
-               }
-               else
-               {
-                       mPreview->setImage("");
-                       mPreview->setVisible(false);
-               }
-       });
+	mMenu.getList()->setCursorChangedCallback([this](CursorState state)
+	{
+		if (mMenu.size() == 0)
+		{
+			mPreview->setVideo("");
+			mPreview->setImage("");
+			mPreview->setVisible(false);
+			return;
+		}
+
+		std::string path = mMenu.getSelected();
+		std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(path));
+		if (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg")
+		{
+			mPreview->setVideo("");
+			mPreview->setImage(path);
+			mPreview->setVisible(true);
+		}
+		else if (ext == ".mp4" || ext == ".avi" || ext == ".mkv" || ext == ".webm")
+		{
+			mPreview->setImage("");
+			mPreview->setVideo(path);
+			mPreview->setVisible(true);
+		}
+		else
+		{
+			mPreview->setVideo("");
+			mPreview->setImage("");
+			mPreview->setVisible(false);
+		}
+	});
 
 	if (mOkCallback != nullptr)
 	{
@@ -90,6 +110,11 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 void GuiFileBrowser::navigateTo(const std::string path)
 {
 	mCurrentPath = path;
+
+	// Reset preview when changing directories
+	mPreview->setVideo("");
+	mPreview->setImage("");
+	mPreview->setVisible(false);
 
 	auto theme = ThemeData::getMenuTheme();
 
@@ -170,30 +195,30 @@ void GuiFileBrowser::navigateTo(const std::string path)
 		}
 	}
 
-        centerWindow();
+	centerWindow();
 
-        if (mMenu.size() > 0 && mMenu.getList()->getCursorChangedCallback())
-                mMenu.getList()->getCursorChangedCallback()(CURSOR_STOPPED);
+	if (mMenu.size() > 0 && mMenu.getList()->getCursorChangedCallback())
+		mMenu.getList()->getCursorChangedCallback()(CURSOR_STOPPED);
 }
 
 void GuiFileBrowser::centerWindow()
 {
-        float previewWidth = Renderer::getScreenWidth() * 0.3f;
-        float menuWidth = Renderer::getScreenWidth() - previewWidth;
+	float previewWidth = Renderer::getScreenWidth() * 0.3f;
+	float menuWidth = Renderer::getScreenWidth() - previewWidth;
 
-        if (Renderer::ScreenSettings::fullScreenMenus())
-        {
-                mMenu.setSize(menuWidth, Renderer::getScreenHeight());
-                mMenu.setPosition(0, 0);
-        }
-        else
-        {
-                mMenu.setSize(menuWidth, Renderer::getScreenHeight() * 0.875f);
-                mMenu.setPosition((Renderer::getScreenWidth() - (menuWidth + previewWidth)) / 2, (Renderer::getScreenHeight() - mMenu.getSize().y()) / 2);
-        }
+	if (Renderer::ScreenSettings::fullScreenMenus())
+	{
+		mMenu.setSize(menuWidth, Renderer::getScreenHeight());
+		mMenu.setPosition(0, 0);
+	}
+	else
+	{
+		mMenu.setSize(menuWidth, Renderer::getScreenHeight() * 0.875f);
+		mMenu.setPosition((Renderer::getScreenWidth() - (menuWidth + previewWidth)) / 2, (Renderer::getScreenHeight() - mMenu.getSize().y()) / 2);
+	}
 
-        mPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
-        mPreview->setMaxSize(previewWidth, mMenu.getSize().y());
+	mPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
+	mPreview->setMaxSize(previewWidth, mMenu.getSize().y());
 }
 
 bool GuiFileBrowser::input(InputConfig* config, Input input)

--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -1,6 +1,7 @@
 #include "guis/GuiFileBrowser.h"
 #include "ApiSystem.h"
 #include "components/OptionListComponent.h"
+#include "components/ImageComponent.h"
 #ifdef _RPI_
 #include "components/VideoPlayerComponent.h"
 #endif
@@ -38,67 +39,86 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 	mSelectedFile = Utils::FileSystem::getCanonicalPath(selectedFile);
 	mOkCallback = okCallback;
 
-        addChild(&mMenu);
+	addChild(&mMenu);
 
-       // Use a single VideoComponent to preview both images and videos
+	// Separate components for images and videos
+	mImage = std::shared_ptr<ImageComponent>(new ImageComponent(window));
+	mImage->setVisible(false);
+	addChild(mImage.get());
+
 #ifdef _RPI_
-       if (Settings::getInstance()->getBool("VideoOmxPlayer"))
-               mPreview = std::shared_ptr<VideoComponent>(new VideoPlayerComponent(window, ""));
-       else
+	if (Settings::getInstance()->getBool("VideoOmxPlayer"))
+	mVideo = std::shared_ptr<VideoComponent>(new VideoPlayerComponent(window, ""));
+	else
 #endif
-               mPreview = std::shared_ptr<VideoComponent>(new VideoVlcComponent(window));
+	mVideo = std::shared_ptr<VideoComponent>(new VideoVlcComponent(window));
 
-       mPreview->setPlayAudio(false);
-       mPreview->setStartDelay(0);
-       mPreview->setVisible(false);
-       addChild(mPreview.get());
+	mVideo->setPlayAudio(false);
+	mVideo->setStartDelay(0);
+	mVideo->setVisible(false);
+	addChild(mVideo.get());
 
-        mMenu.getList()->setCursorChangedCallback([this](CursorState state)
-        {
-               if (mMenu.size() == 0)
-               {
-                       mPreview->setImage("");
-                       mPreview->setVideo("");
-                       mPreview->setVisible(false);
-                       mPreview->onHide();
-                       return;
-               }
+	mMenu.getList()->setCursorChangedCallback([this](CursorState state)
+	{
+	if (mMenu.size() == 0)
+	{
+		       mImage->setImage("");
+		       mImage->setVisible(false);
+		       mVideo->setVideo("");
+		       mVideo->setVisible(false);
+		       mVideo->onHide();
+		       return;
+	}
 
-               std::string path = mMenu.getSelected();
-               std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(path));
-               if (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg")
-               {
-                       mPreview->setVideo("");
-                       mPreview->setImage(path);
-                       mPreview->setVisible(true);
-                       mPreview->onShow();
-               }
-               else if (ext == ".mp4" || ext == ".avi" || ext == ".mkv" || ext == ".webm")
-               {
-                       mPreview->setImage("");
-                       if (!mPreview->setVideo(path))
-                               mPreview->setImage(path);
-                       mPreview->setVisible(true);
-                       mPreview->onShow();
-               }
-               else
-               {
-                       mPreview->setImage("");
-                       mPreview->setVideo("");
-                       mPreview->setVisible(false);
-                       mPreview->onHide();
-               }
-        });
+	std::string path = mMenu.getSelected();
+	std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(path));
+	if (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg")
+	{
+		       mVideo->setVideo("");
+		       mVideo->setVisible(false);
+		       mVideo->onHide();
+
+		       mImage->setImage(path);
+		       mImage->setVisible(true);
+	}
+	else if (ext == ".mp4" || ext == ".avi" || ext == ".mkv" || ext == ".webm")
+	{
+		       mImage->setImage("");
+		       mImage->setVisible(false);
+
+		       if (!mVideo->setVideo(path))
+		       {
+			       mImage->setImage(path);
+			       mImage->setVisible(true);
+			       mVideo->setVideo("");
+			       mVideo->setVisible(false);
+			       mVideo->onHide();
+		       }
+		       else
+		       {
+			       mVideo->setVisible(true);
+			       mVideo->onShow();
+		       }
+	}
+	else
+	{
+		       mImage->setImage("");
+		       mImage->setVisible(false);
+		       mVideo->setVideo("");
+		       mVideo->setVisible(false);
+		       mVideo->onHide();
+	}
+	});
 
 	if (mOkCallback != nullptr)
 	{
 		mMenu.addButton(_("RESET"), "back", [&]
 		{
-			onOk("");			
+			onOk("");
 		});
 	}
 
-    mMenu.addButton(_("BACK"), "back", [&] { delete this; });
+	mMenu.addButton(_("BACK"), "back", [&] { delete this; });
 
 	if (startPath.empty() || !Utils::FileSystem::isDirectory(startPath))
 	{
@@ -116,11 +136,12 @@ void GuiFileBrowser::navigateTo(const std::string path)
 {
 	mCurrentPath = path;
 
-       // Reset previews when changing directories
-       mPreview->setImage("");
-       mPreview->setVideo("");
-       mPreview->setVisible(false);
-       mPreview->onHide();
+	// Reset previews when changing directories
+	mImage->setImage("");
+	mImage->setVisible(false);
+	mVideo->setVideo("");
+	mVideo->setVisible(false);
+	mVideo->onHide();
 
 	auto theme = ThemeData::getMenuTheme();
 
@@ -137,9 +158,9 @@ void GuiFileBrowser::navigateTo(const std::string path)
 		});
 	}
 	files.sort([](const Utils::FileSystem::FileInfo& file1, const Utils::FileSystem::FileInfo& file2) {
-	    auto name1 = Utils::FileSystem::getFileName(file1.path);
-	    auto name2 = Utils::FileSystem::getFileName(file2.path);
-	    return Utils::String::compareIgnoreCase(name1, name2) < 0;
+	auto name1 = Utils::FileSystem::getFileName(file1.path);
+	auto name2 = Utils::FileSystem::getFileName(file2.path);
+	return Utils::String::compareIgnoreCase(name1, name2) < 0;
 	});
 	for (auto file : files)
 	{
@@ -171,8 +192,8 @@ void GuiFileBrowser::navigateTo(const std::string path)
 			std::string ext = Utils::FileSystem::getExtension(file.path);
 
 			std::string icon;
-			
-			
+
+
 
 			if ((mTypes & FileTypes::IMAGES) == FileTypes::IMAGES)
 				if (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg")
@@ -185,7 +206,7 @@ void GuiFileBrowser::navigateTo(const std::string path)
 			if ((mTypes & FileTypes::VIDEO) == FileTypes::VIDEO)
 				if (ext == ".mp4" || ext == ".avi" || ext == ".mkv" || ext == ".webm")
 					icon = VIDEO_ICON;
-				
+
 			if ((mTypes & FileTypes::AUDIO) == FileTypes::AUDIO)
 				if (ext == ".ogg" || ext == ".mp3" || ext == ".wav")
 					icon = AUDIO_ICON;
@@ -195,8 +216,8 @@ void GuiFileBrowser::navigateTo(const std::string path)
 
 			bool isSelected = (mSelectedFile == file.path);
 
-			mMenu.addEntry(icon + Utils::FileSystem::getFileName(file.path), false, 
-				[this, file]() { onOk(file.path); }, 
+			mMenu.addEntry(icon + Utils::FileSystem::getFileName(file.path), false,
+				[this, file]() { onOk(file.path); },
 				"", isSelected, false, file.path, false);
 		}
 	}
@@ -223,8 +244,12 @@ void GuiFileBrowser::centerWindow()
 		mMenu.setPosition((Renderer::getScreenWidth() - (menuWidth + previewWidth)) / 2, (Renderer::getScreenHeight() - mMenu.getSize().y()) / 2);
 	}
 
-       mPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
-       mPreview->setMaxSize(previewWidth, mMenu.getSize().y());
+	float previewX = mMenu.getPosition().x() + mMenu.getSize().x();
+	float previewY = mMenu.getPosition().y();
+	mImage->setPosition(previewX, previewY);
+	mImage->setMaxSize(previewWidth, mMenu.getSize().y());
+	mVideo->setPosition(previewX, previewY);
+	mVideo->setMaxSize(previewWidth, mMenu.getSize().y());
 }
 
 bool GuiFileBrowser::input(InputConfig* config, Input input)
@@ -253,26 +278,26 @@ bool GuiFileBrowser::input(InputConfig* config, Input input)
 	}
 
 	if (config->isMappedTo("start", input) && input.value != 0)
-	{		
+	{
 		if (mMenu.size() && mOkCallback != nullptr)
 		{
 			auto path = mMenu.getSelected();
 
 			if (mTypes == FileTypes::DIRECTORY && path.empty())
-				onOk(mCurrentPath);				
+				onOk(mCurrentPath);
 			else if (!path.empty() && (mTypes == FileTypes::DIRECTORY || !Utils::FileSystem::isDirectory(path)))
 				onOk(path);
 		}
 
-		return true;		
+		return true;
 	}
 
 	if (config->isMappedTo("x", input) && input.value && mOkCallback != nullptr)
 	{
-		onOk("");		
+		onOk("");
 		return true;
 	}
-	
+
 	if (config->isMappedTo("select", input))
 	{
 		navigateTo(Paths::getScreenShotPath());
@@ -285,7 +310,7 @@ bool GuiFileBrowser::input(InputConfig* config, Input input)
 std::vector<HelpPrompt> GuiFileBrowser::getHelpPrompts()
 {
 	std::vector<HelpPrompt> prompts = mMenu.getHelpPrompts();
-	
+
 	if (mOkCallback != nullptr)
 		prompts.push_back(HelpPrompt("x", _("RESET")));
 

--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -63,9 +63,12 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
                {
                        mImagePreview->setImage("");
                        mImagePreview->setVisible(false);
+                       mImagePreview->onHide();
+
                        mVideoPreview->setVideo("");
                        mVideoPreview->setImage("");
                        mVideoPreview->setVisible(false);
+                       mVideoPreview->onHide();
                        return;
                }
 
@@ -76,26 +79,33 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
                        mVideoPreview->setVideo("");
                        mVideoPreview->setImage("");
                        mVideoPreview->setVisible(false);
+                       mVideoPreview->onHide();
 
                        mImagePreview->setImage(path);
                        mImagePreview->setVisible(true);
+                       mImagePreview->onShow();
                }
                else if (ext == ".mp4" || ext == ".avi" || ext == ".mkv" || ext == ".webm")
                {
                        mImagePreview->setImage("");
                        mImagePreview->setVisible(false);
+                       mImagePreview->onHide();
 
                        mVideoPreview->setImage("");
                        mVideoPreview->setVideo(path);
                        mVideoPreview->setVisible(true);
+                       mVideoPreview->onShow();
                }
                else
                {
                        mImagePreview->setImage("");
                        mImagePreview->setVisible(false);
+                       mImagePreview->onHide();
+
                        mVideoPreview->setVideo("");
                        mVideoPreview->setImage("");
                        mVideoPreview->setVisible(false);
+                       mVideoPreview->onHide();
                }
         });
 
@@ -128,9 +138,11 @@ void GuiFileBrowser::navigateTo(const std::string path)
        // Reset previews when changing directories
        mImagePreview->setImage("");
        mImagePreview->setVisible(false);
+       mImagePreview->onHide();
        mVideoPreview->setVideo("");
        mVideoPreview->setImage("");
        mVideoPreview->setVisible(false);
+       mVideoPreview->onHide();
 
 	auto theme = ThemeData::getMenuTheme();
 

--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -2,6 +2,7 @@
 
 #include "ApiSystem.h"
 #include "components/OptionListComponent.h"
+#include "components/ImageComponent.h"
 #ifdef _RPI_
 #include "components/VideoPlayerComponent.h"
 #endif
@@ -39,51 +40,60 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 	mSelectedFile = Utils::FileSystem::getCanonicalPath(selectedFile);
 	mOkCallback = okCallback;
 
-	addChild(&mMenu);
+        addChild(&mMenu);
 
-	// Create video component for preview and disable audio
+        // Create image preview component
+        mImagePreview = std::make_shared<ImageComponent>(window);
+        mImagePreview->setVisible(false);
+        addChild(mImagePreview.get());
+
+        // Create video preview component and disable audio
 #ifdef _RPI_
-	if (Settings::getInstance()->getBool("VideoOmxPlayer"))
-		mPreview = std::shared_ptr<VideoComponent>(new VideoPlayerComponent(window, ""));
-	else
+        if (Settings::getInstance()->getBool("VideoOmxPlayer"))
+                mVideoPreview = std::shared_ptr<VideoComponent>(new VideoPlayerComponent(window, ""));
+        else
 #endif
-		mPreview = std::shared_ptr<VideoComponent>(new VideoVlcComponent(window));
+                mVideoPreview = std::shared_ptr<VideoComponent>(new VideoVlcComponent(window));
 
-	mPreview->setPlayAudio(false);
-	mPreview->setVisible(false);
-	addChild(mPreview.get());
+        mVideoPreview->setPlayAudio(false);
+        mVideoPreview->setVisible(false);
+        addChild(mVideoPreview.get());
 
-	mMenu.getList()->setCursorChangedCallback([this](CursorState state)
-	{
-		if (mMenu.size() == 0)
-		{
-			mPreview->setVideo("");
-			mPreview->setImage("");
-			mPreview->setVisible(false);
-			return;
-		}
+        mMenu.getList()->setCursorChangedCallback([this](CursorState state)
+        {
+                if (mMenu.size() == 0)
+                {
+                        mImagePreview->setImage("");
+                        mImagePreview->setVisible(false);
+                        mVideoPreview->setVideo("");
+                        mVideoPreview->setVisible(false);
+                        return;
+                }
 
-		std::string path = mMenu.getSelected();
-		std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(path));
-		if (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg")
-		{
-			mPreview->setVideo("");
-			mPreview->setImage(path);
-			mPreview->setVisible(true);
-		}
-		else if (ext == ".mp4" || ext == ".avi" || ext == ".mkv" || ext == ".webm")
-		{
-			mPreview->setImage("");
-			mPreview->setVideo(path);
-			mPreview->setVisible(true);
-		}
-		else
-		{
-			mPreview->setVideo("");
-			mPreview->setImage("");
-			mPreview->setVisible(false);
-		}
-	});
+                std::string path = mMenu.getSelected();
+                std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(path));
+                if (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg")
+                {
+                        mVideoPreview->setVideo("");
+                        mVideoPreview->setVisible(false);
+                        mImagePreview->setImage(path);
+                        mImagePreview->setVisible(true);
+                }
+                else if (ext == ".mp4" || ext == ".avi" || ext == ".mkv" || ext == ".webm")
+                {
+                        mImagePreview->setImage("");
+                        mImagePreview->setVisible(false);
+                        mVideoPreview->setVideo(path);
+                        mVideoPreview->setVisible(true);
+                }
+                else
+                {
+                        mImagePreview->setImage("");
+                        mImagePreview->setVisible(false);
+                        mVideoPreview->setVideo("");
+                        mVideoPreview->setVisible(false);
+                }
+        });
 
 	if (mOkCallback != nullptr)
 	{
@@ -111,10 +121,11 @@ void GuiFileBrowser::navigateTo(const std::string path)
 {
 	mCurrentPath = path;
 
-	// Reset preview when changing directories
-	mPreview->setVideo("");
-	mPreview->setImage("");
-	mPreview->setVisible(false);
+        // Reset preview when changing directories
+        mImagePreview->setImage("");
+        mImagePreview->setVisible(false);
+        mVideoPreview->setVideo("");
+        mVideoPreview->setVisible(false);
 
 	auto theme = ThemeData::getMenuTheme();
 
@@ -217,8 +228,10 @@ void GuiFileBrowser::centerWindow()
 		mMenu.setPosition((Renderer::getScreenWidth() - (menuWidth + previewWidth)) / 2, (Renderer::getScreenHeight() - mMenu.getSize().y()) / 2);
 	}
 
-	mPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
-	mPreview->setMaxSize(previewWidth, mMenu.getSize().y());
+        mImagePreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
+        mImagePreview->setMaxSize(previewWidth, mMenu.getSize().y());
+        mVideoPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
+        mVideoPreview->setMaxSize(previewWidth, mMenu.getSize().y());
 }
 
 bool GuiFileBrowser::input(InputConfig* config, Input input)

--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -1,7 +1,6 @@
 #include "guis/GuiFileBrowser.h"
 #include "ApiSystem.h"
 #include "components/OptionListComponent.h"
-#include "components/ImageComponent.h"
 #ifdef _RPI_
 #include "components/VideoPlayerComponent.h"
 #endif
@@ -41,34 +40,27 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 
         addChild(&mMenu);
 
-       mImagePreview = std::make_shared<ImageComponent>(window);
-       mImagePreview->setVisible(false);
-       addChild(mImagePreview.get());
-
+       // Use a single VideoComponent to preview both images and videos
 #ifdef _RPI_
        if (Settings::getInstance()->getBool("VideoOmxPlayer"))
-               mVideoPreview = std::shared_ptr<VideoComponent>(new VideoPlayerComponent(window, ""));
+               mPreview = std::shared_ptr<VideoComponent>(new VideoPlayerComponent(window, ""));
        else
 #endif
-               mVideoPreview = std::shared_ptr<VideoComponent>(new VideoVlcComponent(window));
+               mPreview = std::shared_ptr<VideoComponent>(new VideoVlcComponent(window));
 
-       mVideoPreview->setPlayAudio(false);
-       mVideoPreview->setVisible(false);
-       mVideoPreview->setStartDelay(0);
-       addChild(mVideoPreview.get());
+       mPreview->setPlayAudio(false);
+       mPreview->setStartDelay(0);
+       mPreview->setVisible(false);
+       addChild(mPreview.get());
 
         mMenu.getList()->setCursorChangedCallback([this](CursorState state)
         {
                if (mMenu.size() == 0)
                {
-                       mImagePreview->setImage("");
-                       mImagePreview->setVisible(false);
-                       mImagePreview->onHide();
-
-                       mVideoPreview->setVideo("");
-                       mVideoPreview->setImage("");
-                       mVideoPreview->setVisible(false);
-                       mVideoPreview->onHide();
+                       mPreview->setImage("");
+                       mPreview->setVideo("");
+                       mPreview->setVisible(false);
+                       mPreview->onHide();
                        return;
                }
 
@@ -76,36 +68,25 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
                std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(path));
                if (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg")
                {
-                       mVideoPreview->setVideo("");
-                       mVideoPreview->setImage("");
-                       mVideoPreview->setVisible(false);
-                       mVideoPreview->onHide();
-
-                       mImagePreview->setImage(path);
-                       mImagePreview->setVisible(true);
-                       mImagePreview->onShow();
+                       mPreview->setVideo("");
+                       mPreview->setImage(path);
+                       mPreview->setVisible(true);
+                       mPreview->onShow();
                }
                else if (ext == ".mp4" || ext == ".avi" || ext == ".mkv" || ext == ".webm")
                {
-                       mImagePreview->setImage("");
-                       mImagePreview->setVisible(false);
-                       mImagePreview->onHide();
-
-                       mVideoPreview->setImage("");
-                       mVideoPreview->setVideo(path);
-                       mVideoPreview->setVisible(true);
-                       mVideoPreview->onShow();
+                       mPreview->setImage("");
+                       if (!mPreview->setVideo(path))
+                               mPreview->setImage(path);
+                       mPreview->setVisible(true);
+                       mPreview->onShow();
                }
                else
                {
-                       mImagePreview->setImage("");
-                       mImagePreview->setVisible(false);
-                       mImagePreview->onHide();
-
-                       mVideoPreview->setVideo("");
-                       mVideoPreview->setImage("");
-                       mVideoPreview->setVisible(false);
-                       mVideoPreview->onHide();
+                       mPreview->setImage("");
+                       mPreview->setVideo("");
+                       mPreview->setVisible(false);
+                       mPreview->onHide();
                }
         });
 
@@ -136,13 +117,10 @@ void GuiFileBrowser::navigateTo(const std::string path)
 	mCurrentPath = path;
 
        // Reset previews when changing directories
-       mImagePreview->setImage("");
-       mImagePreview->setVisible(false);
-       mImagePreview->onHide();
-       mVideoPreview->setVideo("");
-       mVideoPreview->setImage("");
-       mVideoPreview->setVisible(false);
-       mVideoPreview->onHide();
+       mPreview->setImage("");
+       mPreview->setVideo("");
+       mPreview->setVisible(false);
+       mPreview->onHide();
 
 	auto theme = ThemeData::getMenuTheme();
 
@@ -245,11 +223,8 @@ void GuiFileBrowser::centerWindow()
 		mMenu.setPosition((Renderer::getScreenWidth() - (menuWidth + previewWidth)) / 2, (Renderer::getScreenHeight() - mMenu.getSize().y()) / 2);
 	}
 
-       mImagePreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
-       mImagePreview->setMaxSize(previewWidth, mMenu.getSize().y());
-
-       mVideoPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
-       mVideoPreview->setMaxSize(previewWidth, mMenu.getSize().y());
+       mPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
+       mPreview->setMaxSize(previewWidth, mMenu.getSize().y());
 }
 
 bool GuiFileBrowser::input(InputConfig* config, Input input)

--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -2,7 +2,6 @@
 
 #include "ApiSystem.h"
 #include "components/OptionListComponent.h"
-#include "components/ImageComponent.h"
 #ifdef _RPI_
 #include "components/VideoPlayerComponent.h"
 #endif
@@ -42,31 +41,26 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 
         addChild(&mMenu);
 
-        // Create image preview component
-        mImagePreview = std::make_shared<ImageComponent>(window);
-        mImagePreview->setVisible(false);
-        addChild(mImagePreview.get());
-
-        // Create video preview component and disable audio
+        // Create preview component capable of images and videos
 #ifdef _RPI_
         if (Settings::getInstance()->getBool("VideoOmxPlayer"))
-                mVideoPreview = std::shared_ptr<VideoComponent>(new VideoPlayerComponent(window, ""));
+                mPreview = std::shared_ptr<VideoComponent>(new VideoPlayerComponent(window, ""));
         else
 #endif
-                mVideoPreview = std::shared_ptr<VideoComponent>(new VideoVlcComponent(window));
+                mPreview = std::shared_ptr<VideoComponent>(new VideoVlcComponent(window));
 
-        mVideoPreview->setPlayAudio(false);
-        mVideoPreview->setVisible(false);
-        addChild(mVideoPreview.get());
+        mPreview->setPlayAudio(false);
+        mPreview->setVisible(false);
+        mPreview->setStartDelay(0);
+        addChild(mPreview.get());
 
         mMenu.getList()->setCursorChangedCallback([this](CursorState state)
         {
                 if (mMenu.size() == 0)
                 {
-                        mImagePreview->setImage("");
-                        mImagePreview->setVisible(false);
-                        mVideoPreview->setVideo("");
-                        mVideoPreview->setVisible(false);
+                        mPreview->setVideo("");
+                        mPreview->setImage("");
+                        mPreview->setVisible(false);
                         return;
                 }
 
@@ -74,24 +68,21 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
                 std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(path));
                 if (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg")
                 {
-                        mVideoPreview->setVideo("");
-                        mVideoPreview->setVisible(false);
-                        mImagePreview->setImage(path);
-                        mImagePreview->setVisible(true);
+                        mPreview->setVideo("");
+                        mPreview->setImage(path);
+                        mPreview->setVisible(true);
                 }
                 else if (ext == ".mp4" || ext == ".avi" || ext == ".mkv" || ext == ".webm")
                 {
-                        mImagePreview->setImage("");
-                        mImagePreview->setVisible(false);
-                        mVideoPreview->setVideo(path);
-                        mVideoPreview->setVisible(true);
+                        mPreview->setImage("");
+                        mPreview->setVideo(path);
+                        mPreview->setVisible(true);
                 }
                 else
                 {
-                        mImagePreview->setImage("");
-                        mImagePreview->setVisible(false);
-                        mVideoPreview->setVideo("");
-                        mVideoPreview->setVisible(false);
+                        mPreview->setVideo("");
+                        mPreview->setImage("");
+                        mPreview->setVisible(false);
                 }
         });
 
@@ -122,10 +113,9 @@ void GuiFileBrowser::navigateTo(const std::string path)
 	mCurrentPath = path;
 
         // Reset preview when changing directories
-        mImagePreview->setImage("");
-        mImagePreview->setVisible(false);
-        mVideoPreview->setVideo("");
-        mVideoPreview->setVisible(false);
+        mPreview->setVideo("");
+        mPreview->setImage("");
+        mPreview->setVisible(false);
 
 	auto theme = ThemeData::getMenuTheme();
 
@@ -228,10 +218,8 @@ void GuiFileBrowser::centerWindow()
 		mMenu.setPosition((Renderer::getScreenWidth() - (menuWidth + previewWidth)) / 2, (Renderer::getScreenHeight() - mMenu.getSize().y()) / 2);
 	}
 
-        mImagePreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
-        mImagePreview->setMaxSize(previewWidth, mMenu.getSize().y());
-        mVideoPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
-        mVideoPreview->setMaxSize(previewWidth, mMenu.getSize().y());
+        mPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
+        mPreview->setMaxSize(previewWidth, mMenu.getSize().y());
 }
 
 bool GuiFileBrowser::input(InputConfig* config, Input input)

--- a/es-app/src/guis/GuiFileBrowser.h
+++ b/es-app/src/guis/GuiFileBrowser.h
@@ -7,6 +7,7 @@
 template<typename T>
 class OptionListComponent;
 
+class ImageComponent;
 class VideoComponent;
 
 class GuiFileBrowser : public GuiComponent
@@ -37,7 +38,8 @@ private:
        std::string mCurrentPath;
        std::string mSelectedFile;
        FileTypes   mTypes;
-       std::shared_ptr<VideoComponent> mPreview;
+       std::shared_ptr<ImageComponent> mImage;
+       std::shared_ptr<VideoComponent> mVideo;
 
         std::function<void(const std::string&)> mOkCallback;
 };

--- a/es-app/src/guis/GuiFileBrowser.h
+++ b/es-app/src/guis/GuiFileBrowser.h
@@ -7,6 +7,7 @@
 template<typename T>
 class OptionListComponent;
 
+class ImageComponent;
 class VideoComponent;
 
 class GuiFileBrowser : public GuiComponent
@@ -34,10 +35,11 @@ private:
 
         MenuComponent mMenu;
 
-        std::string mCurrentPath;
+       std::string mCurrentPath;
        std::string mSelectedFile;
        FileTypes   mTypes;
-       std::shared_ptr<VideoComponent> mPreview;
+       std::shared_ptr<ImageComponent> mImagePreview;
+       std::shared_ptr<VideoComponent> mVideoPreview;
 
         std::function<void(const std::string&)> mOkCallback;
 };

--- a/es-app/src/guis/GuiFileBrowser.h
+++ b/es-app/src/guis/GuiFileBrowser.h
@@ -7,7 +7,7 @@
 template<typename T>
 class OptionListComponent;
 
-class ImageComponent;
+class VideoComponent;
 
 class GuiFileBrowser : public GuiComponent
 {
@@ -35,9 +35,9 @@ private:
         MenuComponent mMenu;
 
         std::string mCurrentPath;
-        std::string mSelectedFile;
-        FileTypes   mTypes;
-        std::shared_ptr<ImageComponent> mPreview;
+       std::string mSelectedFile;
+       FileTypes   mTypes;
+       std::shared_ptr<VideoComponent> mPreview;
 
         std::function<void(const std::string&)> mOkCallback;
 };

--- a/es-app/src/guis/GuiFileBrowser.h
+++ b/es-app/src/guis/GuiFileBrowser.h
@@ -7,6 +7,7 @@
 template<typename T>
 class OptionListComponent;
 
+class ImageComponent;
 class VideoComponent;
 
 class GuiFileBrowser : public GuiComponent
@@ -37,7 +38,8 @@ private:
        std::string mCurrentPath;
        std::string mSelectedFile;
        FileTypes   mTypes;
-       std::shared_ptr<VideoComponent> mPreview;
+       std::shared_ptr<ImageComponent> mImagePreview;
+       std::shared_ptr<VideoComponent> mVideoPreview;
 
         std::function<void(const std::string&)> mOkCallback;
 };

--- a/es-app/src/guis/GuiFileBrowser.h
+++ b/es-app/src/guis/GuiFileBrowser.h
@@ -7,7 +7,6 @@
 template<typename T>
 class OptionListComponent;
 
-class ImageComponent;
 class VideoComponent;
 
 class GuiFileBrowser : public GuiComponent
@@ -38,8 +37,7 @@ private:
        std::string mCurrentPath;
        std::string mSelectedFile;
        FileTypes   mTypes;
-       std::shared_ptr<ImageComponent> mImage;
-       std::shared_ptr<VideoComponent> mVideo;
+       std::shared_ptr<VideoComponent> mPreview;
 
         std::function<void(const std::string&)> mOkCallback;
 };

--- a/es-app/src/guis/GuiFileBrowser.h
+++ b/es-app/src/guis/GuiFileBrowser.h
@@ -7,7 +7,6 @@
 template<typename T>
 class OptionListComponent;
 
-class ImageComponent;
 class VideoComponent;
 
 class GuiFileBrowser : public GuiComponent
@@ -38,8 +37,7 @@ private:
        std::string mCurrentPath;
        std::string mSelectedFile;
        FileTypes   mTypes;
-       std::shared_ptr<ImageComponent> mImagePreview;
-       std::shared_ptr<VideoComponent> mVideoPreview;
+       std::shared_ptr<VideoComponent> mPreview;
 
         std::function<void(const std::string&)> mOkCallback;
 };


### PR DESCRIPTION
## Summary
- Display selected video files in the file browser
- Use VideoComponent for previewing images and videos with audio muted
- Clear preview when changing directories

## Testing
- `make test` (fails: No rule to make target 'test')
- `cmake -S . -B build` (fails: Could NOT find OpenGL)

------
https://chatgpt.com/codex/tasks/task_e_68c3da3b65288320a251f7d274eb88ae