### PR TITLE
Add video preview to file browser

### DIFF
--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -10,6 +10,8 @@
 #include "components/MultiLineMenuEntry.h"
 #include "GuiLoading.h"
 #include "guis/GuiMsgBox.h"
+#include "ThemeData.h"
+#include "utils/FileSystemUtil.h"
 #include "components/VideoVlcComponent.h"
 #include "components/VideoPlayerComponent.h"
 #include "Settings.h"

--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -10,6 +10,9 @@
 #include "components/MultiLineMenuEntry.h"
 #include "GuiLoading.h"
 #include "guis/GuiMsgBox.h"
+#include "components/VideoVlcComponent.h"
+#include "components/VideoPlayerComponent.h"
+#include "Settings.h"
 #include <cstring>
 #include "SystemConf.h"
 #include "Paths.h"
@@ -31,10 +34,20 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 	setTag("popup");
 
 	mTypes = types;
-	mSelectedFile = Utils::FileSystem::getCanonicalPath(selectedFile);
-	mOkCallback = okCallback;
+        mSelectedFile = Utils::FileSystem::getCanonicalPath(selectedFile);
+        mOkCallback = okCallback;
 
-	addChild(&mMenu);
+        addChild(&mMenu);
+
+#ifdef _RPI_
+        if (Settings::getInstance()->getBool("VideoOmxPlayer"))
+                mPreview = new VideoPlayerComponent(mWindow, "");
+        else
+#endif
+                mPreview = new VideoVlcComponent(mWindow);
+
+        mPreview->setOrigin(0.0f, 0.0f);
+        addChild(mPreview);
 
 	if (mOkCallback != nullptr)
 	{
@@ -54,8 +67,13 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 
 		navigateTo(mCurrentPath);
 	}
-	else
-		navigateTo(startPath);
+        else
+                navigateTo(startPath);
+}
+
+GuiFileBrowser::~GuiFileBrowser()
+{
+        delete mPreview;
 }
 
 void GuiFileBrowser::navigateTo(const std::string path)
@@ -101,10 +119,10 @@ void GuiFileBrowser::navigateTo(const std::string path)
 		}, "", isSelected, false, file.path, false);
 	}
 
-	if (mTypes != FileTypes::DIRECTORY)
-	{
-		for (auto file : files)
-		{
+        if (mTypes != FileTypes::DIRECTORY)
+        {
+                for (auto file : files)
+                {
 			if (file.directory || file.hidden)
 				continue;
 
@@ -138,21 +156,46 @@ void GuiFileBrowser::navigateTo(const std::string path)
 			mMenu.addEntry(icon + Utils::FileSystem::getFileName(file.path), false, 
 				[this, file]() { onOk(file.path); }, 
 				"", isSelected, false, file.path, false);
-		}
-	}
+                }
+        }
 
-	centerWindow();	
+        mMenu.getList()->setCursorChangedCallback([this](CursorState state)
+        {
+                if (state == CURSOR_STOPPED)
+                        updatePreview(mMenu.getSelected());
+        });
+
+        updatePreview(mMenu.getSelected());
+
+        centerWindow();
 }
 
 void GuiFileBrowser::centerWindow()
 {
-	if (Renderer::ScreenSettings::fullScreenMenus())
-		mMenu.setSize(Renderer::getScreenWidth(), Renderer::getScreenHeight());
-	else
-	{
-		mMenu.setSize(mMenu.getSize().x(), Renderer::getScreenHeight() * 0.875f);
-		mMenu.setPosition((Renderer::getScreenWidth() - mMenu.getSize().x()) / 2, (Renderer::getScreenHeight() - mMenu.getSize().y()) / 2);
-	}
+        float height = Renderer::ScreenSettings::fullScreenMenus() ? Renderer::getScreenHeight() : Renderer::getScreenHeight() * 0.875f;
+        float menuWidth = Renderer::getScreenWidth() * 0.6f;
+        float previewWidth = Renderer::getScreenWidth() - menuWidth;
+        float y = (Renderer::getScreenHeight() - height) / 2;
+
+        mMenu.setSize(menuWidth, height);
+        mMenu.setPosition(0, y);
+
+        if (mPreview)
+        {
+                mPreview->setSize(previewWidth, height);
+                mPreview->setPosition(menuWidth, y);
+        }
+}
+
+void GuiFileBrowser::updatePreview(const std::string& path)
+{
+        if (!mPreview)
+                return;
+
+        if (Utils::FileSystem::isVideo(path))
+                mPreview->setVideo(path);
+        else
+                mPreview->stopVideo();
 }
 
 bool GuiFileBrowser::input(InputConfig* config, Input input)

--- a/es-app/src/guis/GuiFileBrowser.h
+++ b/es-app/src/guis/GuiFileBrowser.h
@@ -22,7 +22,12 @@ public:
 		ALL = 255
 	};
 
-        GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types = FileTypes::IMAGES, const std::function<void(const std::string&)>& okCallback = nullptr, const std::string& title = "");
+        GuiFileBrowser(Window* window,
+                       const std::string startPath,
+                       const std::string selectedFile,
+                       FileTypes types = FileTypes::IMAGES,
+                       const std::function<void(const std::string&)>& okCallback = nullptr,
+                       const std::string& title = "");
         ~GuiFileBrowser();
 
 	bool input(InputConfig* config, Input input) override;
@@ -34,7 +39,7 @@ private:
 	void centerWindow();
 
         MenuComponent mMenu;
-        VideoComponent* mPreview;
+        VideoComponent* mPreview = nullptr;
         void updatePreview(const std::string& path);
 
         std::string mCurrentPath;

--- a/es-app/src/guis/GuiFileBrowser.h
+++ b/es-app/src/guis/GuiFileBrowser.h
@@ -7,6 +7,8 @@
 template<typename T>
 class OptionListComponent;
 
+class VideoComponent;
+
 class GuiFileBrowser : public GuiComponent
 {
 public:
@@ -20,7 +22,8 @@ public:
 		ALL = 255
 	};
 
-	GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types = FileTypes::IMAGES, const std::function<void(const std::string&)>& okCallback = nullptr, const std::string& title = "");
+        GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types = FileTypes::IMAGES, const std::function<void(const std::string&)>& okCallback = nullptr, const std::string& title = "");
+        ~GuiFileBrowser();
 
 	bool input(InputConfig* config, Input input) override;
 	virtual std::vector<HelpPrompt> getHelpPrompts() override;
@@ -30,11 +33,13 @@ private:
 	void navigateTo(const std::string path);
 	void centerWindow();
 
-	MenuComponent mMenu;	
+        MenuComponent mMenu;
+        VideoComponent* mPreview;
+        void updatePreview(const std::string& path);
 
-	std::string mCurrentPath;
-	std::string mSelectedFile;
-	FileTypes   mTypes;
+        std::string mCurrentPath;
+        std::string mSelectedFile;
+        FileTypes   mTypes;
 
 	std::function<void(const std::string&)> mOkCallback;
 };


### PR DESCRIPTION
## Summary
- allow GuiFileBrowser to preview videos via new VideoComponent
- split layout to show menu and preview side by side
- update video when selection changes and clean up preview

## Testing
- `cmake -S . -B build` (fails: Could NOT find OpenGL)
- `cmake --build build` (fails: No rule to make target 'Makefile')

------
https://chatgpt.com/codex/tasks/task_e_68c516e287a08320b5e9499ac7877e86