### PR TITLE
Add video preview for splash videos

### DIFF
--- a/es-app/src/guis/GuiFileBrowser.cpp
+++ b/es-app/src/guis/GuiFileBrowser.cpp
@@ -3,6 +3,7 @@
 #include "ApiSystem.h"
 #include "components/OptionListComponent.h"
 #include "components/ImageComponent.h"
+#include "resources/TextureResource.h"
 #include "utils/StringUtil.h"
 #include "guis/GuiSettings.h"
 #include "views/ViewController.h"
@@ -10,11 +11,18 @@
 #include "SystemData.h"
 #include "LocaleES.h"
 #include "components/MultiLineMenuEntry.h"
-#include "GuiLoading.h"
 #include "guis/GuiMsgBox.h"
 #include <cstring>
 #include "SystemConf.h"
 #include "Paths.h"
+#include "utils/Platform.h"
+#include "utils/FileSystemUtil.h"
+#include <algorithm>
+
+#include <string>
+
+#define PREVIEW_SECONDS 5
+#define PREVIEW_FPS 10
 
 #define WINDOW_WIDTH (float)Math::max((int)Renderer::getScreenHeight(), (int)(Renderer::getScreenWidth() * 0.65f))
 
@@ -28,7 +36,7 @@
 
 
 GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types, const std::function<void(const std::string&)>& okCallback, const std::string& title)
-	: GuiComponent(window), mMenu(window, title.empty() ? _("FILE BROWSER") : title)
+        : GuiComponent(window), mMenu(window, title.empty() ? _("FILE BROWSER") : title)
 {
 	setTag("popup");
 
@@ -38,9 +46,23 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 
         addChild(&mMenu);
 
-        mPreview = std::make_shared<ImageComponent>(window);
+       mPreview = std::make_shared<ImageComponent>(window);
        mPreview->setVisible(false);
+       mPreview->setAllowFading(false);
        addChild(mPreview.get());
+
+       mLoadingBg = std::make_shared<ImageComponent>(window);
+       mLoadingBg->setVisible(false);
+       mLoadingBg->setImage(":/white.png");
+       mLoadingBg->setColorShift(0x000000FF);
+       addChild(mLoadingBg.get());
+
+       mCurrentFrame = 0;
+       mFrameTime = 0;
+       mGeneratingPreview = false;
+       mExpectedFrames = 0;
+       mLastFrameCount = 0;
+       mNoFrameTime = 0;
 
        mMenu.getList()->setCursorChangedCallback([this](CursorState state)
        {
@@ -48,6 +70,7 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
                {
                        mPreview->setImage("");
                        mPreview->setVisible(false);
+                       clearVideoPreview();
                        return;
                }
 
@@ -55,11 +78,17 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
                std::string ext = Utils::String::toLower(Utils::FileSystem::getExtension(path));
                if (ext == ".jpg" || ext == ".png" || ext == ".gif" || ext == ".svg")
                {
+                       clearVideoPreview();
                        mPreview->setImage(path);
                        mPreview->setVisible(true);
                }
+               else if (ext == ".mp4" || ext == ".avi" || ext == ".mkv" || ext == ".webm")
+               {
+                       generateVideoPreview(path);
+               }
                else
                {
+                       clearVideoPreview();
                        mPreview->setImage("");
                        mPreview->setVisible(false);
                }
@@ -84,7 +113,71 @@ GuiFileBrowser::GuiFileBrowser(Window* window, const std::string startPath, cons
 		navigateTo(mCurrentPath);
 	}
 	else
-		navigateTo(startPath);
+               navigateTo(startPath);
+}
+
+GuiFileBrowser::~GuiFileBrowser()
+{
+       clearVideoPreview();
+}
+
+void GuiFileBrowser::update(int deltaTime)
+{
+       GuiComponent::update(deltaTime);
+
+       if (mGeneratingPreview)
+       {
+               auto files = Utils::FileSystem::getDirectoryFiles(mTempPreviewDir);
+               files.sort([](const Utils::FileSystem::FileInfo& a, const Utils::FileSystem::FileInfo& b) { return a.path < b.path; });
+
+               for (auto file : files)
+               {
+                       if (file.directory)
+                               continue;
+
+                       if (Utils::String::toLower(Utils::FileSystem::getExtension(file.path)) != ".png")
+                               continue;
+
+                       if (std::find(mVideoFrames.begin(), mVideoFrames.end(), file.path) == mVideoFrames.end())
+                       {
+                               mVideoFrames.push_back(file.path);
+                               // Force-load textures so the preview doesn't flicker on first playthrough
+                               mFrameTextures.push_back(TextureResource::get(file.path, false, true, true));
+                       }
+               }
+
+               if ((int)mVideoFrames.size() >= mExpectedFrames)
+                       mGeneratingPreview = false;
+               else if ((int)mVideoFrames.size() == mLastFrameCount)
+               {
+                       mNoFrameTime += deltaTime;
+                       if (mNoFrameTime > 1000)
+                               mGeneratingPreview = false;
+               }
+               else
+               {
+                       mLastFrameCount = (int)mVideoFrames.size();
+                       mNoFrameTime = 0;
+               }
+       }
+
+       if (!mGeneratingPreview && !mFrameTextures.empty() && !mPreview->isVisible())
+       {
+               mPreview->setImage(mFrameTextures[0]);
+               mPreview->setVisible(true);
+               mLoadingBg->setVisible(false);
+       }
+
+       if (mPreview->isVisible() && !mFrameTextures.empty())
+       {
+               mFrameTime += deltaTime;
+               if (mFrameTime > 100)
+               {
+                       mFrameTime = 0;
+                       mCurrentFrame = (mCurrentFrame + 1) % mFrameTextures.size();
+                       mPreview->setImage(mFrameTextures[mCurrentFrame]);
+               }
+       }
 }
 
 void GuiFileBrowser::navigateTo(const std::string path)
@@ -188,12 +281,67 @@ void GuiFileBrowser::centerWindow()
         }
         else
         {
-                mMenu.setSize(menuWidth, Renderer::getScreenHeight() * 0.875f);
-                mMenu.setPosition((Renderer::getScreenWidth() - (menuWidth + previewWidth)) / 2, (Renderer::getScreenHeight() - mMenu.getSize().y()) / 2);
-        }
+       mMenu.setSize(menuWidth, Renderer::getScreenHeight() * 0.875f);
+       mMenu.setPosition((Renderer::getScreenWidth() - (menuWidth + previewWidth)) / 2, (Renderer::getScreenHeight() - mMenu.getSize().y()) / 2);
+       }
 
-        mPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
-        mPreview->setMaxSize(previewWidth, mMenu.getSize().y());
+       mPreview->setPosition(mMenu.getPosition().x() + mMenu.getSize().x(), mMenu.getPosition().y());
+       mPreview->setMaxSize(previewWidth, mMenu.getSize().y());
+
+       mLoadingBg->setPosition(mPreview->getPosition());
+       mLoadingBg->setSize(previewWidth, mMenu.getSize().y());
+}
+
+void GuiFileBrowser::generateVideoPreview(const std::string& path)
+{
+       clearVideoPreview();
+
+       mTempPreviewDir = Utils::FileSystem::getTempPath() + "/videopreview";
+       Utils::FileSystem::createDirectory(mTempPreviewDir);
+
+       std::string command = "ffmpeg -hide_banner -loglevel error -y -i \"" + path +
+               "\" -t " + std::to_string(PREVIEW_SECONDS) +
+               " -vf \"fps=" + std::to_string(PREVIEW_FPS) +
+               ",scale=720:480:force_original_aspect_ratio=decrease\" \"" +
+               mTempPreviewDir + "/frame_%03d.png\"";
+       Utils::Platform::ProcessStartInfo psi(command);
+       psi.waitForExit = false;
+       psi.run();
+
+       mGeneratingPreview = true;
+       mExpectedFrames = PREVIEW_SECONDS * PREVIEW_FPS;
+       mLastFrameCount = 0;
+       mNoFrameTime = 0;
+       mCurrentFrame = 0;
+       mFrameTime = 0;
+       mPreview->setImage("");
+       mPreview->setVisible(false);
+       mLoadingBg->setVisible(true);
+}
+
+void GuiFileBrowser::clearVideoPreview()
+{
+       mGeneratingPreview = false;
+
+#ifndef WIN32
+       Utils::Platform::ProcessStartInfo kill("killall -q ffmpeg");
+       kill.run();
+#endif
+
+       for (auto& img : mVideoFrames)
+               Utils::FileSystem::removeFile(img);
+
+       if (!mTempPreviewDir.empty())
+               Utils::FileSystem::removeDirectory(mTempPreviewDir);
+
+       mVideoFrames.clear();
+       mFrameTextures.clear();
+       mTempPreviewDir.clear();
+       mCurrentFrame = 0;
+       mFrameTime = 0;
+       mLoadingBg->setVisible(false);
+       mLastFrameCount = 0;
+       mNoFrameTime = 0;
 }
 
 bool GuiFileBrowser::input(InputConfig* config, Input input)

--- a/es-app/src/guis/GuiFileBrowser.h
+++ b/es-app/src/guis/GuiFileBrowser.h
@@ -7,37 +7,54 @@
 template<typename T>
 class OptionListComponent;
 
+#include <memory>
 class ImageComponent;
+class TextureResource;
+#include <vector>
 
 class GuiFileBrowser : public GuiComponent
 {
 public:
-	enum FileTypes
-	{
-		IMAGES = 1,
-		MANUALS = 2,
-		VIDEO = 3,
-		DIRECTORY = 4,
-		AUDIO = 5,
-		ALL = 255
-	};
+       enum FileTypes
+       {
+               IMAGES     = 1 << 0,
+               MANUALS    = 1 << 1,
+               VIDEO      = 1 << 2,
+               DIRECTORY  = 1 << 3,
+               AUDIO      = 1 << 4,
+               ALL        = 0xFFFFFFFF
+       };
 
-	GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types = FileTypes::IMAGES, const std::function<void(const std::string&)>& okCallback = nullptr, const std::string& title = "");
+        GuiFileBrowser(Window* window, const std::string startPath, const std::string selectedFile, FileTypes types = FileTypes::IMAGES, const std::function<void(const std::string&)>& okCallback = nullptr, const std::string& title = "");
+        ~GuiFileBrowser() override;
 
-	bool input(InputConfig* config, Input input) override;
-	virtual std::vector<HelpPrompt> getHelpPrompts() override;
+        bool input(InputConfig* config, Input input) override;
+        void update(int deltaTime) override;
+        virtual std::vector<HelpPrompt> getHelpPrompts() override;
 
 private:
         void onOk(const std::string& path);
         void navigateTo(const std::string path);
         void centerWindow();
+        void generateVideoPreview(const std::string& path);
+        void clearVideoPreview();
 
         MenuComponent mMenu;
 
         std::string mCurrentPath;
         std::string mSelectedFile;
-        FileTypes   mTypes;
-        std::shared_ptr<ImageComponent> mPreview;
+       FileTypes   mTypes;
+       std::shared_ptr<ImageComponent> mPreview;
+       std::shared_ptr<ImageComponent> mLoadingBg;
+       std::vector<std::string> mVideoFrames;
+       std::vector<std::shared_ptr<TextureResource>> mFrameTextures;
+        int mCurrentFrame;
+        int mFrameTime;
+        std::string mTempPreviewDir;
+       bool mGeneratingPreview;
+       int mExpectedFrames;
+       int mLastFrameCount;
+       int mNoFrameTime;
 
         std::function<void(const std::string&)> mOkCallback;
 };


### PR DESCRIPTION
## Summary
- Use bitmask file-type flags so custom splash video browsing lists only video files
- Preload preview frames and disable fading to avoid flicker
- Extract five-second frame sequences for video previews
- Display a black placeholder until frames are ready instead of a spinner
- Terminate prior ffmpeg processes when navigating to prevent slowdowns
- Force-load preview textures so the video plays smoothly on first loop
- Downscale extracted frames to 720x480 to prevent flicker on high-resolution videos
- Centralize preview duration and fps constants for easier tuning

## Testing
- `cmake -S . -B build -DGLES=ON -DGL=OFF` *(fails: Required library FreeImage not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5470d776483209ffb417acc5a12d7